### PR TITLE
Add missing #import

### DIFF
--- a/MQL4/Include/OTMql4/OTLibStrings.mqh
+++ b/MQL4/Include/OTMql4/OTLibStrings.mqh
@@ -15,3 +15,5 @@
 string uAnsi2Unicode(int ptrStringMemory);
 void vStringToArray(string uInput, string& uOutput[], string uDelim);
 string uStringReplace(string uHaystack, string uNeedle, string uReplace);
+
+#import


### PR DESCRIPTION
This small PR adds a missing closing  #import to OTLibStrings.mqh
