### PR TITLE
Fix return type of bOTLibServerErrorType

### DIFF
--- a/MQL4/Libraries/OTMql4/OTLibServerErrors.mq4
+++ b/MQL4/Libraries/OTMql4/OTLibServerErrors.mq4
@@ -31,12 +31,12 @@
 bool bOTLibServerErrorIsContinuable(int iErr) {
      int i;
 
-     i = bOTLibServerErrorType(iErr);
+     i = nOTLibServerErrorType(iErr);
      // Im not really sure what "commonerror" is (OFLIB_OTHER_ERROR)
      return(i == OFLIB_BUSY_ERROR || i == OFLIB_NETWORK_ERROR);
 }
 
-bool bOTLibServerErrorType(int iErr) {
+int nOTLibServerErrorType(int iErr) {
     //  Group the errors returned from trade server
     //  so that we can take action based on classes of errors.
     switch(iErr) {


### PR DESCRIPTION
The bool to int casting throws errors in MetaTrader5